### PR TITLE
codeigniter-ion-auth-migration meta table

### DIFF
--- a/001_Create_ion_auth.php
+++ b/001_Create_ion_auth.php
@@ -140,7 +140,6 @@ class Migration_Create_ion_auth extends	CI_Migration {
 		$this->use_config();
 		
 		$this->dbforge->drop_table($this->groups);
-		$this->dbforge->drop_table($this->meta);
 		$this->dbforge->drop_table($this->users);
 		$this->dbforge->drop_table("{$this->users}_{$this->groups}");
 	}


### PR DESCRIPTION
I installed BenEdmund's CodeIgniter-Ion-Auth stuff today along with codeigniter-ion-auth-migration.

I noticed Ben's stuff doesn't use a 'meta' table, so I removed it from your migration and now those two items work together.
